### PR TITLE
fix: buttons no longer hidden after restart

### DIFF
--- a/app.js
+++ b/app.js
@@ -34,6 +34,7 @@ for(var i = 0; i < buttons.length; i++){
 document.getElementById('start').addEventListener("click", function(){
     document.getElementById('startPopup').style.visibility = 'hidden';
     document.getElementById('detector_events').hidden = false;
+    document.getElementById('inputbuttons').style.visibility = 'visible';
 
     if(game.difficulty == 3){
         document.getElementById('correctWrongContainer').style.display = 'none';


### PR DESCRIPTION
Fixes a bug where the buttons are invisible after a restart.

### How to reproduce the bug
1. Start the game with any difficulty except for free-play.
2. End the game by guessing incorrectly.
3. Click `RESTART`.
4. Start the game with any difficulty.

The new game starts but the buttons stay hidden.


### Cause
After a game (in the endGame function), all input buttons are hidden:
https://github.com/rory8599/rory8599.github.io/blob/b4462c0051fec7365e3e950b8c68c4d23061b2b3/app.js#L260-L262
However, when the game starts again, the buttons are never set to be visible again.

### Fix
The bug is fixed by adding the following line to the `click` event listener on the start button.
```js
    document.getElementById('inputbuttons').style.visibility = 'visible';
```